### PR TITLE
Normalize outputs in GraphSAGE and GAT layers

### DIFF
--- a/model/base_gnn.py
+++ b/model/base_gnn.py
@@ -82,6 +82,7 @@ class GAT(nn.Module):
         x = torch.cat([att(x, adj) for att in self.attentions], dim=1)
         x = F.dropout(x, self.dropout, training=self.training)
         x = F.elu(self.out_att(x, adj))
+        x = F.normalize(x)
         # print(x)
         return x
 
@@ -104,4 +105,5 @@ class GraphSAGE(nn.Module):
         x = F.normalize(x)
 
         x = self.fc(x)
+        x = F.normalize(x)
         return x #F.log_softmax(x, dim=1)


### PR DESCRIPTION
## Summary
- normalize GraphSAGE output after final linear layer
- normalize GAT output after final attention layer

## Testing
- `pytest` *(no tests found)*