### PR TITLE
Enable model selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ To install required packages
 ## 3. Experiments
 For reproducibility, please run these commands regarding to specific dataset:
 
-- python main_cond.py --dataset=Cora/Citeseer/CS/Actor
+- python main_cond.py --dataset=Cora/Citeseer/CS/Actor --model=gcn
+
+The `--model` flag chooses the GNN architecture. Available options are `gcn`,
+`sage`, and `gat`.
 
 ## 4. Citation

--- a/main_cond.py
+++ b/main_cond.py
@@ -116,9 +116,12 @@ def run(args, data, save_path, seed, device):
     model_path = os.path.join(save_path, 'model_{:d}.pkl'.format(seed))
     in_feat = data.feat.shape[1]
 
-    model = GCN(in_feat, args.nhid, args)
-    # model = GraphSAGE(in_feat, args.nhid, args)
-    # model = GAT(in_feat, args.nhid, args)
+    if args.model == "sage":
+        model = GraphSAGE(in_feat, args.nhid, args)
+    elif args.model == "gat":
+        model = GAT(in_feat, args.nhid, args)
+    else:
+        model = GCN(in_feat, args.nhid, args)
 
     optimizer = torch.optim.Adam(model.parameters(),\
                                  lr=args.lr, weight_decay=args.decay)

--- a/utils.py
+++ b/utils.py
@@ -28,7 +28,13 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--dataset', type=str, default='Cora', help='dataset')
-    parser.add_argument('--model', type=str, default='', help='model')
+    parser.add_argument(
+        '--model',
+        type=str,
+        default='gcn',
+        choices=['gcn', 'sage', 'gat'],
+        help='GNN model to use: gcn, sage, or gat'
+    )
     parser.add_argument('--task', type=str, default='link', help='task: node, link')
 
     parser.add_argument('--ds_path', type=str, default='data')


### PR DESCRIPTION
## Summary
- allow choosing GCN, GraphSAGE or GAT via `--model` argument
- instantiate selected model in `main_cond.py`
- document `--model` usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`